### PR TITLE
chore: Add environment variable - LOCAL_WORKSPACE_FOLDER for source code mounting in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,6 @@
 		"ethan-reesor.vscode-go-test-adapter",
 		"ms-vscode.test-adapter-converter"
 	],
-	
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	"remoteEnv": { "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}" }
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ In addition to binaries, a Docker image is available. The image can be run as fo
 docker run --rm -v "$(pwd):/repo" jjliggett/jjversion
 ```
 
+Within the devcontainer, the image can be run as follows:
+
+```sh
+docker run --rm -v "$LOCAL_WORKSPACE_FOLDER:/repo" jjliggett/jjversion
+```
+
 The image is available on both GitHub Container Registry and Docker Hub.
 
 ## Licensing


### PR DESCRIPTION
This change puts ${localWorkspaceFolder} into an
environment variable called LOCAL_WORKSPACE_FOLDER,
which lets us use the environment variable when making
bind mounts like the following:

docker run --rm -v "$LOCAL_WORKSPACE_FOLDER:/repo" jjliggett/jjversion

Documentation can be found at https://git.io/JaCjj
eg. github.com / microsoft / vscode-dev-containers /
containers / docker-from-docker

( https://github.com/microsoft/vscode-dev-containers/tree/main/containers/docker-from-docker )