### PR TITLE
minor:  Add /src to the end of the module path

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -35,14 +35,14 @@ jobs:
         working-directory: src
       - run: go test
         working-directory: src
-      - run: go build
+      - run: go build -o jjversion
         working-directory: src
   
       - run: sudo mv src/jjversion /usr/local/bin
       - run: jjversion
       - run: echo "VERSION=$(jjversion | jq --raw-output '.MajorMinorPatch')" >> $GITHUB_ENV
       - run: sudo rm /usr/local/bin/jjversion
-      - run: go build -ldflags "-X main.appVersion=${{ env.VERSION }}"
+      - run: go build -o jjversion -ldflags "-X main.appVersion=${{ env.VERSION }}"
         working-directory: src
       - run: sudo cp src/jjversion /usr/local/bin
       - run: jjversion

--- a/.github/workflows/devcontainer-ci.yaml
+++ b/.github/workflows/devcontainer-ci.yaml
@@ -36,7 +36,7 @@ jobs:
             cd src
             go vet
             go test
-            go build
+            go build -o jjversion
             cd ..
             src/jjversion
             src/jjversion | jq --raw-output '.MajorMinorPatch'

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 
 COPY src ./
 
-RUN go build -ldflags "-X main.appVersion=${VERSION}"
+RUN go build -o jjversion -ldflags "-X main.appVersion=${VERSION}"
 
 FROM alpine:3.14.2@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a
 WORKDIR '/repo'

--- a/README.md
+++ b/README.md
@@ -56,5 +56,6 @@ dependencies can be found at [docs/NOTICE.md](docs/NOTICE.md).
 ## Build Locally
 
 ```sh
-go build -ldflags "-X main.appVersion=42.10.0"
+cd src
+go build -o jjversion -ldflags "-X main.appVersion=42.10.0"
 ```

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,4 +1,4 @@
-module github.com/jjliggett/jjversion
+module github.com/jjliggett/jjversion/src
 
 go 1.16
 


### PR DESCRIPTION
This is a breaking change for dependents which
build jjversion.

It is now necessary to specify ```-o jjversion``` like so: ```go build -o jjversion```