### PR TITLE
ci: Remove matrix-test from workflow

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -95,25 +95,6 @@ jobs:
       - run: docker run --rm jjliggett/jjversion-test
       - run: make test
 
-  matrix-test:
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11, windows-2016, windows-2019, windows-2022]
-        go: [1.12.x, 1.13.x, 1.14.x, 1.15.x, 1.16.x, 1.17.x]
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: pwsh
-    steps:
-      - uses: actions/checkout@230611dbd0eb52da1e1f4f7bc8bb0c3a339fc8b7
-      - uses: actions/setup-go@02f7ea9f09887fd7fd6c77c49a0f72a2e8cde95c
-        with:
-          go-version: ${{ matrix.go }}
-      - run: go vet
-      - run: go test ./...
-      - run: go build -a -v
-      - run: ls
-
   build-cross-compilation:
     runs-on: ubuntu-latest
     needs: initial-build
@@ -144,7 +125,6 @@ jobs:
       - initial-build
       - docker-build
       - docker-test
-      - matrix-test
       - test-release-branch
       - test-release-branch-and-tag
       - test-commit-incrementing


### PR DESCRIPTION
The matrix-test portion of the workflow has been
flaky and takes a considerable amount of time.