### PR TITLE
ci: Fix auto release action

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -346,8 +346,10 @@ jobs:
 
       - name: Create GitHub release
         uses: marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1
-        if: ${{ github.ref == 'refs/heads/root' && env.VERSION != env.PREVIOUS_COMMIT_VERSION }}
+        #if: ${{ github.ref == 'refs/heads/root' && env.VERSION != env.PREVIOUS_COMMIT_VERSION }}
+        if: ${{ github.ref == 'refs/heads/root' }}
         with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: v${{ env.VERSION }}
           files: |
             jjversion-${{ env.VERSION }}-linux-x64.zip


### PR DESCRIPTION
This fixes the following issue:

`Run marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1
Error: Input required and not supplied: repo_token
(node:1971) UnhandledPromiseRejectionWarning: Error: Input required and not supplied: repo_token
    at Object.f [as getInput] (/home/runner/work/_actions/marvinpinto/action-automatic-releases/d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1/dist/index.js:1:1[21](https://github.com/jjliggett/jjversion/runs/5085997689?check_suite_focus=true#step:68:21)98)
    at /home/runner/work/_actions/marvinpinto/action-automatic-releases/d68defdd11f9dcc7f52f35c1b7c[23](https://github.com/jjliggett/jjversion/runs/5085997689?check_suite_focus=true#step:68:23)6ee7513bcc1/dist/index.js:1:214337
    at /home/runner/work/_actions/marvinpinto/action-automatic-releases/d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1/dist/index.js:1:214698
    at Generator.next (<anonymous>)
    at /home/runner/work/_actions/marvinpinto/action-automatic-releases/d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1/dist/index.js:1:212987
    at new Promise (<anonymous>)
    at s (/home/runner/work/_actions/marvinpinto/action-automatic-releases/d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1/dist/index.js:1:212732)
    at Object.t.main (/home/runner/work/_actions/marvinpinto/action-automatic-releases/d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1/dist/index.js:1:214262)
    at Object.<anonymous> (/home/runner/work/_actions/marvinpinto/action-automatic-releases/d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1/dist/index.js:1:212105)
    at r (/home/runner/work/_actions/marvinpinto/action-automatic-releases/d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1/dist/index.js:1:1[24](https://github.com/jjliggett/jjversion/runs/5085997689?check_suite_focus=true#step:68:24))
(node:1971) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:1971) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.`

https://github.com/jjliggett/jjversion/runs/5085997689?check_suite_focus=true