### PR TITLE
ci: Refine workflow trigger conditions and update devcontainers-ci references

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -8,6 +8,8 @@ on:
       - '.github/workflows/codeql-analysis.yaml'
       - '.github/workflows/devcontainer-ci.yaml'
       - '.github/dependabot.yaml'
+    branches:
+      - root
   pull_request:
     paths-ignore:
       - README.md
@@ -16,6 +18,7 @@ on:
       - '.github/workflows/codeql-analysis.yaml'
       - '.github/workflows/devcontainer-ci.yaml'
       - '.github/dependabot.yaml'
+  workflow_dispatch:
 
 jobs:
   initial-build:

--- a/.github/workflows/devcontainer-ci.yaml
+++ b/.github/workflows/devcontainer-ci.yaml
@@ -8,6 +8,8 @@ on:
       - '.github/workflows/actions.yaml'
       - '.github/workflows/codeql-analysis.yaml'
       - '.github/dependabot.yaml'
+    branches:
+      - root
   pull_request:
     paths-ignore:
       - README.md
@@ -16,6 +18,7 @@ on:
       - '.github/workflows/actions.yaml'
       - '.github/workflows/codeql-analysis.yaml'
       - '.github/dependabot.yaml'
+  workflow_dispatch:
 
 jobs:
   devcontainer-ci:
@@ -27,7 +30,7 @@ jobs:
       - name: Setup Docker BuildKit
         uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
       - name: Build and run dev container task
-        uses: stuartleeks/devcontainer-build-run@afa58a5848bbf08f67d2a6be8935cf8121802362
+        uses: devcontainers/ci@afa58a5848bbf08f67d2a6be8935cf8121802362
         with:
           imageName: ghcr.io/jjliggett/jjversion-dc
           runCmd: |

--- a/docs/ATTRIBUTIONS.md
+++ b/docs/ATTRIBUTIONS.md
@@ -74,7 +74,7 @@ Note, VS Code Dev Containers is a development tool that utilizes a Docker contai
 - <https://github.com/actions/download-artifact>
 - <https://github.com/docker/login-action>
 - <https://github.com/github/codeql-action>
-- <https://github.com/stuartleeks/devcontainer-build-run>
+- <https://github.com/devcontainers/ci>
 - <https://github.com/marvinpinto/action-automatic-releases>
 - <https://github.com/Checkmarx/kics-github-action>
 

--- a/docs/attributions/devcontainers-ci-LICENSE.md
+++ b/docs/attributions/devcontainers-ci-LICENSE.md
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2021 Stuart Leeks
+Copyright (c) Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This change prevents duplicate pull request workflow executions.

The ```workflow_dispatch``` trigger was added so that testing on a branch can be performed without opening a pull request.

Additionally, it updates the devcontainers-ci references along with the updated copyright for that action.

This is similar to https://github.com/jjliggett/CurrentTimeApp/pull/50 and it relates to the devcontainers-ci pull request here: https://github.com/devcontainers/ci/pull/130 which happened after the repository was transferred.