### PR TITLE
fix: Better support merge commits

### DIFF
--- a/jjvercore/git.go
+++ b/jjvercore/git.go
@@ -34,5 +34,5 @@ func (gs gitService) getRepositoryTagObjects(r *git.Repository) (*object.TagIter
 }
 
 func (gs gitService) getRepositoryCommits(r *git.Repository) (object.CommitIter, error) {
-	return r.Log(&git.LogOptions{})
+	return r.Log(&git.LogOptions{Order: git.LogOrderCommitterTime})
 }


### PR DESCRIPTION
Commits are now obtained with
`LogOrderCommitterTime`, which
makes it so that versions are more
accurate when merge commits are
used.

As detailed below, `LogOrderCommitterTime` is more compatible with `log order`. The default algorithm is depth-first search which caused the versioning to be inaccurate when merge commits instead of fast-forward.

https://github.com/go-git/go-git/blob/736622fb5d9a058a887667d57c91dc1b58aca6ea/options.go#L398-L401

![image](https://user-images.githubusercontent.com/67353173/209897239-31b58b7e-5873-47e5-bf42-9d02da05fcd4.png)

As detailed in this comment, this change was successful: https://github.com/jjliggett/jjversion/pull/180#issuecomment-1367037651