### PR TITLE
chore: Ignore .vscode/settings.json

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/codeql-analysis.yaml'
       - '.github/workflows/devcontainer-ci.yaml'
       - '.github/dependabot.yaml'
+      - '.gitignore'
     branches:
       - root
   pull_request:
@@ -18,6 +19,7 @@ on:
       - '.github/workflows/codeql-analysis.yaml'
       - '.github/workflows/devcontainer-ci.yaml'
       - '.github/dependabot.yaml'
+      - '.gitignore'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/devcontainer-ci.yaml
+++ b/.github/workflows/devcontainer-ci.yaml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/actions.yaml'
       - '.github/workflows/codeql-analysis.yaml'
       - '.github/dependabot.yaml'
+      - '.gitignore'
     branches:
       - root
   pull_request:
@@ -18,6 +19,7 @@ on:
       - '.github/workflows/actions.yaml'
       - '.github/workflows/codeql-analysis.yaml'
       - '.github/dependabot.yaml'
+      - '.gitignore'
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json


### PR DESCRIPTION
This creates a .gitignore file and adds .vscode/settings.json to it.

That file contains various VS Code configuration, such as Peacock color customizations. Those configurations should be excluded from the repository.
