### PR TITLE
ci(deps): Update artifact actions to new major versions

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -48,7 +48,7 @@ jobs:
       - run: jjversion --version
       - run: jjversion --help
       - name: Upload jjversion
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: jjversion
           path: jjversion
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Docker BuildKit
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
       - name: Download jjversion
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion
       - run: chmod +x jjversion
@@ -87,7 +87,7 @@ jobs:
       - run: docker run --rm jjliggett/jjversion jjversion --version
       - run: docker save jjliggett/jjversion > jjversion.tar
       - name: Upload jjversion.tar
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: jjversion.tar
           path: jjversion.tar
@@ -145,50 +145,50 @@ jobs:
       - run: env GOOS=windows GOARCH=arm go build -a -v -o jjversion-${{ env.VERSION }}-windows-arm/jjversion.exe -ldflags "-X main.appVersion=${{ env.VERSION }}"
 
       - name: Upload jjversion docs
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: jjversion-${{ env.VERSION }}-docs
           path: docs/
 
       - name: Upload jjversion linux x64
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: jjversion-${{ env.VERSION }}-linux-x64
           path: jjversion-${{ env.VERSION }}-linux-x64/
       - name: Upload jjversion linux arm64
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: jjversion-${{ env.VERSION }}-linux-arm64
           path: jjversion-${{ env.VERSION }}-linux-arm64/
       - name: Upload jjversion linux arm
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: jjversion-${{ env.VERSION }}-linux-arm
           path: jjversion-${{ env.VERSION }}-linux-arm/
       - name: Upload jjversion linux 386
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: jjversion-${{ env.VERSION }}-linux-386
           path: jjversion-${{ env.VERSION }}-linux-386/
 
       - name: Upload jjversion darwin amd64
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: jjversion-${{ env.VERSION }}-darwin-amd64
           path: jjversion-${{ env.VERSION }}-darwin-amd64/
 
       - name: Upload jjversion windows x64
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: jjversion-${{ env.VERSION }}-windows-x64
           path: jjversion-${{ env.VERSION }}-windows-x64/
       - name: Upload jjversion windows 386
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: jjversion-${{ env.VERSION }}-windows-386
           path: jjversion-${{ env.VERSION }}-windows-386/
       - name: Upload jjversion windows arm
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: jjversion-${{ env.VERSION }}-windows-arm
           path: jjversion-${{ env.VERSION }}-windows-arm/
@@ -217,7 +217,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download jjversion
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion
 
@@ -230,42 +230,42 @@ jobs:
       - run: echo "PREVIOUS_COMMIT_VERSION=$(jjversion | jq --raw-output '.MajorMinorPatch')" >> $GITHUB_ENV
 
       - name: Download jjversion linux x64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion-${{ env.VERSION }}-linux-x64
           path: jjversion-${{ env.VERSION }}-linux-x64/
       - name: Download jjversion linux arm64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion-${{ env.VERSION }}-linux-arm64
           path: jjversion-${{ env.VERSION }}-linux-arm64/
       - name: Download jjversion linux arm
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion-${{ env.VERSION }}-linux-arm
           path: jjversion-${{ env.VERSION }}-linux-arm/
       - name: Download jjversion linux 386
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion-${{ env.VERSION }}-linux-386
           path: jjversion-${{ env.VERSION }}-linux-386/
       - name: Download jjversion darwin amd64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion-${{ env.VERSION }}-darwin-amd64
           path: jjversion-${{ env.VERSION }}-darwin-amd64/
       - name: Download jjversion windows x64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion-${{ env.VERSION }}-windows-x64
           path: jjversion-${{ env.VERSION }}-windows-x64/
       - name: Download jjversion windows 386
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion-${{ env.VERSION }}-windows-386
           path: jjversion-${{ env.VERSION }}-windows-386/
       - name: Download jjversion windows arm
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion-${{ env.VERSION }}-windows-arm
           path: jjversion-${{ env.VERSION }}-windows-arm/
@@ -309,13 +309,13 @@ jobs:
       - run: zip jjversion-${{ env.VERSION }}-artifacts.zip jjversion-${{ env.VERSION }}-linux-x64.zip jjversion-${{ env.VERSION }}-linux-arm64.zip jjversion-${{ env.VERSION }}-linux-arm.zip jjversion-${{ env.VERSION }}-linux-386.zip jjversion-${{ env.VERSION }}-darwin-amd64.zip jjversion-${{ env.VERSION }}-windows-x64.zip jjversion-${{ env.VERSION }}-windows-386.zip jjversion-${{ env.VERSION }}-windows-arm.zip
       - run: ls -R
       - name: Upload jjversion
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: jjversion-${{ env.VERSION }}-artifacts.zip
           path: jjversion-${{ env.VERSION }}-artifacts.zip
 
       - name: Download jjversion.tar
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion.tar
       - run: docker load < jjversion.tar
@@ -384,7 +384,7 @@ jobs:
       - run: git checkout -b release/10.42.11
       - run: git commit -m "initial commit" --allow-empty
       - name: Download jjversion
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion
       - run: chmod +x jjversion
@@ -410,7 +410,7 @@ jobs:
       - run: git tag v42.43.44
       - run: git tag -a v100.100.100 -m "v100.100.100"
       - name: Download jjversion
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion
       - run: chmod +x jjversion
@@ -423,7 +423,7 @@ jobs:
     needs: initial-build
     steps:
       - name: Download jjversion
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion
       - run: chmod +x jjversion
@@ -466,7 +466,7 @@ jobs:
     needs: initial-build
     steps:
       - name: Download jjversion
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion
       - run: chmod +x jjversion
@@ -495,7 +495,7 @@ jobs:
     needs: initial-build
     steps:
       - name: Download jjversion
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion
       - run: chmod +x jjversion
@@ -531,7 +531,7 @@ jobs:
       - run: git checkout -b release/10.42.11
       - run: git commit -m "initial commit" --allow-empty
       - name: Download jjversion.tar
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion.tar
       - run: docker load < jjversion.tar
@@ -555,7 +555,7 @@ jobs:
       - run: git tag v42.43.44
       - run: git tag -a v100.100.100 -m "v100.100.100"
       - name: Download jjversion.tar
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion.tar
       - run: docker load < jjversion.tar
@@ -566,7 +566,7 @@ jobs:
     needs: docker-build
     steps:
       - name: Download jjversion.tar
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion.tar
       - run: docker load < jjversion.tar
@@ -608,7 +608,7 @@ jobs:
     needs: docker-build
     steps:
       - name: Download jjversion.tar
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion.tar
       - run: docker load < jjversion.tar
@@ -636,7 +636,7 @@ jobs:
     needs: docker-build
     steps:
       - name: Download jjversion.tar
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion.tar
       - run: docker load < jjversion.tar
@@ -665,7 +665,7 @@ jobs:
     needs: initial-build
     steps:
       - name: Download jjversion
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion
       - run: chmod +x jjversion
@@ -702,7 +702,7 @@ jobs:
     needs: initial-build
     steps:
       - name: Download jjversion
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: jjversion
       - run: chmod +x jjversion


### PR DESCRIPTION
This pull request consists of major upgrades for the artifact actions. The artifacts architecture has received a very significant upgrade. This includes several improvements, including major performance improvements (much faster upload and download times) and other useful enhancements as well.

More information can be seen here: https://github.com/actions/toolkit/blob/5430c5d84832076372990c7c27f900878ff66dc9/packages/artifact/README.md#v2---whats-new

This closes #300 and it closes #305

![image](https://github.com/jjliggett/jjversion/assets/67353173/db336c60-4776-446d-a58d-52754146fdb7)