### PR TITLE
ci: Add devcontainers to dependabot.yaml & add devcontainer-lock.json

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+    "features": {
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1.3": {
+            "version": "1.3.1",
+            "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:ae9cd59950da8ae5c31658a905afbc43a10f75ff6ed0dbe0fca27fa2134dc124",
+            "integrity": "sha256:ae9cd59950da8ae5c31658a905afbc43a10f75ff6ed0dbe0fca27fa2134dc124"
+        },
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "version": "2.3.0",
+            "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:b1eb0e78fd8fc79ac12cac8ef5e821e030da2da56adc651667c15335ea7b6ced",
+            "integrity": "sha256:b1eb0e78fd8fc79ac12cac8ef5e821e030da2da56adc651667c15335ea7b6ced"
+        },
+        "ghcr.io/devcontainers/features/go:1": {
+            "version": "1.2.2",
+            "resolved": "ghcr.io/devcontainers/features/go@sha256:d5e34970f31942a4d9f6b3f6f52da1176b2dcb35aeba3f0fc93b974e287d3b16",
+            "integrity": "sha256:d5e34970f31942a4d9f6b3f6f52da1176b2dcb35aeba3f0fc93b974e287d3b16"
+        }
+    }
+}

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -38,3 +38,16 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    assignees:
+      - "jjliggett"
+    reviewers:
+      - "jjliggett"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
For context, see: https://github.blog/changelog/2024-01-24-dependabot-version-updates-support-devcontainers/